### PR TITLE
added NautilusAPI 4 support, fixed filename bug

### DIFF
--- a/context_menu/linux_menus.py
+++ b/context_menu/linux_menus.py
@@ -161,7 +161,7 @@ class NautilusMenu:
         '''
         # nautilus extensions doesn't work with filenames with spaces
         # Example menu item -> ExampleMenuItem
-        self.name = "".join([word.title() for word in name.split()])
+        self.name = "".join([word.title() for word in name.split()]) if len(name.split()) > 0 else name
         self.sub_items = sub_items
         self.type = type
         self.counter = 0


### PR DESCRIPTION
Added support for Nautilus API 4.0. The current version was not working with version 4.0 due to the changes in the API.
* [Migrating to Nautilus API 4.0](https://gnome.pages.gitlab.gnome.org/nautilus-python/nautilus-python-migrating-to-4.html)

Fixed 2 bugs:
1. Using the same `ExampleMenuProvider` class name for every menu was causing them to override each other. Now it's using the menu name as the class name.
2. Nautilus extensions were not working with filenames using spaces in them. Now it converts the menu names with spaces to PascalCase. (fixes #6 and possibly fixes #18)