### PR TITLE
Raise an exception when type is None

### DIFF
--- a/context_menu/menus.py
+++ b/context_menu/menus.py
@@ -56,6 +56,9 @@ class ContextMenu:
         """
         Recognizes the current platform and passes information to the respective menu. Creates the actual menu.
         """
+        if self.type is None:
+            raise Exception("type can't be None for top-level ContextMenu")
+
         if platform.system() == "Linux":
             linux_menus.NautilusMenu(self.name, self.sub_items, self.type).compile()
         if platform.system() == "Windows":


### PR DESCRIPTION
As the parameter `type` can be `None` in ContextMenu, it's unclear at first glance why creating a ContextMenu without a `type`, and calling compile on it, raises the exception `'NoneType' object has no attribute 'upper'`.

```
cm = ContextMenu("Name")
cm.compile() <- exception
```

This change adds a better error message for when compile is called on the top-level ContextMenu, so that it's more clear what the problem is

Ref #31