### PR TITLE
Fix file extension, add DESKTOP type for windows context menu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ can reference this table to determine the `type`:
 | DIRECTORY            | HKEY_CURRENT_USER\\Software\\Classes\\Directory\\shell             | Opens on a directory                     |
 | DIRECTORY_BACKGROUND | HKEY_CURRENT_USER\\Software\\Classes\\Directory\\Background\\shell | Opens on the background of the Directory |
 | DRIVE                | HKEY_CURRENT_USER\\Software\\Classes\\Drive\\shell                 | Opens on the drives(think USBs)          |
+| DESKTOP              | Software\\Classes\\DesktopBackground\\shell                        | Opens on the background of the desktop   |
 
 * * *
 

--- a/context_menu/windows_menus.py
+++ b/context_menu/windows_menus.py
@@ -148,7 +148,7 @@ except:
 # These are the paths in the registry that correlate to when the context menu is fired.
 # For example, FILES is when a file is right clicked
 CONTEXT_SHORTCUTS = {
-    "FILELOC": "Software\\Classes",
+    "FILELOC": "Software\\Classes\\SystemFileAssociations",
     "FILES": "Software\\Classes\\*\\shell",
     "DIRECTORY": "Software\\Classes\\Directory\\shell",
     "DIRECTORY_BACKGROUND": "Software\\Classes\\Directory\\Background\\shell",

--- a/context_menu/windows_menus.py
+++ b/context_menu/windows_menus.py
@@ -153,6 +153,7 @@ CONTEXT_SHORTCUTS = {
     "DIRECTORY": "Software\\Classes\\Directory\\shell",
     "DIRECTORY_BACKGROUND": "Software\\Classes\\Directory\\Background\\shell",
     "DRIVE": "Software\\Classes\\Drive\\shell",
+    "DESKTOP": "Software\\Classes\\DesktopBackground\\shell",
 }
 
 # Not used yet, but could be useful in the future

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -145,7 +145,7 @@ def test_context_command(
         (
             ".txt",
             {"command": "echo hello"},
-            "Software\\Classes\\.txt\\shell",
+            "Software\\Classes\\SystemFileAssociations\\.txt\\shell",
             "echo hello",
         ),
     ),

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -88,7 +88,7 @@ def test_context_menu_nested(
             "DESKTOP",
             {"python": foo},
             "Software\\Classes\\DesktopBackground\\shell",
-            '''"{}" -c "import sys; import os; sys.path.insert(0, '{}'); import test_windows; test_windows.foo([os.getcwd()],'')"'''.format(
+            '''"{}" -c "import sys; sys.path.insert(0, '{}'); import test_windows; test_windows.foo([' '.join(sys.argv[1:]) ],'')" "%1"'''.format(
                 sys.executable, Path(__file__).parent.as_posix()
             ),
         ),

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -83,6 +83,15 @@ def test_context_menu_nested(
                 sys.executable, Path(__file__).parent.as_posix()
             ),
         ),
+        # Test with DESKTOP
+        (
+            "DESKTOP",
+            {"python": foo},
+            "Software\\Classes\\DesktopBackground\\shell",
+            '''"{}" -c "import sys; import os; sys.path.insert(0, '{}'); import test_windows; test_windows.foo([os.getcwd()],'')"'''.format(
+                sys.executable, Path(__file__).parent.as_posix()
+            ),
+        ),
     ),
 )
 def test_context_command(


### PR DESCRIPTION
Hi!

I noticed a bug where context menus don't work on file extension, I found the problem and fixed it, at least now I have it working.

Also I added a new DESKTOP type, this is a context menu that opens when you click on the desktop, added tests to it and added a description in README.md